### PR TITLE
fix: no strategy needed for python versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,9 +9,9 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.12", "3.13", "3.14.0-alpha.7"]
+    # strategy:
+    #   matrix:
+    #     python-version: ["3.12", "3.13", "3.14.0-alpha.7"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,4 @@ dmypy.json
 *.bak
 .vscode
 .idea
+.*_cache/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,6 @@ version = "0.1.0"
 description = "A project that builds a Django based REST API from scratch"
 readme = "README.md"
 requires-python = ">=3.12"
-dependencies = [
-
-]
 
 [tool.uv]
 dev-dependencies = [
@@ -24,7 +21,7 @@ extensions.front-matter.enabled = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "--cov=. --cov-report=term-missing --cov-fail-under=80 --strict-markers --import-mode=importlib --durations=5 --last-failed -n logical"
+#addopts = "--cov=. --cov-report=term-missing --cov-fail-under=80 --strict-markers --import-mode=importlib --durations=5 --last-failed -n logical"
 pythonpath = ["."]
 
 [tool.coverage.run]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow to run tests on a single Python version instead of multiple versions.
  - Added a rule to ignore hidden cache directories in version control.
  - Removed an unused dependencies field from project configuration.
  - Disabled custom pytest options in the project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->